### PR TITLE
Fix issue with private repositories not being indexed

### DIFF
--- a/cmd/zoekt-mirror-github/main.go
+++ b/cmd/zoekt-mirror-github/main.go
@@ -62,6 +62,7 @@ func main() {
 	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".github-token")); err == nil {
 		*token = filepath.Join(os.Getenv("HOME"), ".github-token")
 	}
+
 	forks := flag.Bool("forks", false, "also mirror forks.")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")

--- a/cmd/zoekt-mirror-github/main.go
+++ b/cmd/zoekt-mirror-github/main.go
@@ -62,7 +62,6 @@ func main() {
 	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".github-token")); err == nil {
 		*token = filepath.Join(os.Getenv("HOME"), ".github-token")
 	}
-
 	forks := flag.Bool("forks", false, "also mirror forks.")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")
@@ -173,7 +172,6 @@ func main() {
 	{
 		trimmed := repos[:0]
 		for _, r := range repos {
-			// fmt.Println(*r.Name)
 			if filter.Include(*r.Name) {
 				trimmed = append(trimmed, r)
 			}

--- a/cmd/zoekt-mirror-github/main.go
+++ b/cmd/zoekt-mirror-github/main.go
@@ -62,7 +62,7 @@ func main() {
 	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".github-token")); err == nil {
 		*token = filepath.Join(os.Getenv("HOME"), ".github-token")
 	}
-	
+
 	forks := flag.Bool("forks", false, "also mirror forks.")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")
@@ -141,7 +141,11 @@ func main() {
 	if *org != "" {
 		repos, err = getOrgRepos(client, *org, reposFilters)
 	} else if *user != "" {
-		repos, err = getUserRepos(client, *user, reposFilters)
+		if *token != "" {
+			repos, err = getUserRepos(client, "", reposFilters)
+		} else {
+			repos, err = getUserRepos(client, *user, reposFilters)
+		}
 	} else {
 		log.Printf("no user or org specified, cloning all repos.")
 		repos, err = getUserRepos(client, "", reposFilters)
@@ -169,6 +173,7 @@ func main() {
 	{
 		trimmed := repos[:0]
 		for _, r := range repos {
+			// fmt.Println(*r.Name)
 			if filter.Include(*r.Name) {
 				trimmed = append(trimmed, r)
 			}


### PR DESCRIPTION
Issue template for later::

### Problem
When running `zoekt-mirror-github` with the `-user` flag specified, private repositories are not indexed even when a valid `.github-token` file is present.

### Repro steps:
1. Create `~/.github-token` with a valid PAT token
1. Run the following command:
`zoekt-mirror-github -dest data -delete -user userName`
1. Observe the repositories indexed

### Expected:
All repositories (both public and private) associated with the user should be indexed.

### Actual:
Only public repositories are indexed

How this PR fixes it:
By using a empty string for the user, the go github library will fallback on using the `users/repos` endpoint instead of the `users/{user-name}/repos` endpoint. For whatever reason, the latter does not return private repositories even when a authentication token is provided. The former does. Thus, this is a quick n' dirty fix that gets around this issue.

From the github library:
<img width="980" alt="image" src="https://github.com/user-attachments/assets/9f7143af-9020-4382-bbe5-e71b9ed08fe6">
