### PR TITLE
Add reposet token to query parser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,20 @@
       "args": ["-index", "${input:indexPath}"]
     },
     {
+      "name": "Webserver (rpc)",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "cmd/zoekt-webserver",
+      "cwd": "${workspaceFolder}",
+      "args": ["-index", "${input:indexPath}", "-rpc"],
+      // Set a long watchdog tick to help with debugging
+      "env": {
+        "ZOEKT_WATCHDOG_TICK": "24h",
+        "SRC_LOG_LEVEL": "debug"
+      }
+    },
+    {
       "name": "Attach to Process (from list)",
       "type": "go",
       "request": "attach",

--- a/query/parse.go
+++ b/query/parse.go
@@ -241,10 +241,6 @@ func parseExpr(in []byte) (Q, int, error) {
 		// Later we will lift this into a root, like we do for caseQ
 		expr = &Type{Type: t, Child: nil}
 	case tokRepoSet:
-		if text == "" {
-			return nil, 0, fmt.Errorf("the reposet: atom must have an argument")
-		}
-
 		// Split the text by commas to get individual repo names
 		repos := strings.Split(text, ",")
 		set := make(map[string]bool)

--- a/query/parse.go
+++ b/query/parse.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"regexp/syntax"
+	"strings"
 
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt/internal/languages"
@@ -239,6 +240,22 @@ func parseExpr(in []byte) (Q, int, error) {
 		}
 		// Later we will lift this into a root, like we do for caseQ
 		expr = &Type{Type: t, Child: nil}
+	case tokRepoSet:
+		if text == "" {
+			return nil, 0, fmt.Errorf("the reposet: atom must have an argument")
+		}
+
+		// Split the text by commas to get individual repo names
+		repos := strings.Split(text, ",")
+		set := make(map[string]bool)
+		for _, repo := range repos {
+			repo = strings.TrimSpace(repo)
+			if repo != "" {
+				set[repo] = true
+			}
+		}
+
+		expr = &RepoSet{Set: set}
 	}
 
 	return expr, len(in) - len(b), nil
@@ -392,6 +409,7 @@ const (
 	tokArchived   = 15
 	tokPublic     = 16
 	tokFork       = 17
+	tokRepoSet    = 18
 )
 
 var tokNames = map[int]string{
@@ -412,6 +430,7 @@ var tokNames = map[int]string{
 	tokLang:       "Language",
 	tokSym:        "Symbol",
 	tokType:       "Type",
+	tokRepoSet:    "RepoSet",
 }
 
 var prefixes = map[string]int{
@@ -432,6 +451,7 @@ var prefixes = map[string]int{
 	"sym:":      tokSym,
 	"t:":        tokType,
 	"type:":     tokType,
+	"reposet:":  tokRepoSet,
 }
 
 var reservedWords = map[string]int{


### PR DESCRIPTION
This PR adds a `reposet:` token to the zoekt query parser. See the corresponding search contexts PR here: https://github.com/sourcebot-dev/sourcebot/pull/273