### PR TITLE
chore: Add ability to plumb opaque ID into a shard at index time with `zoekt-git-index`

### DIFF
--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -46,6 +46,7 @@ func run() int {
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
 	languageMap := flag.String("language_map", "", "a mapping between a language and its ctags processor (a:0,b:3).")
 	tenantID := flag.Int("tenant_id", 0, "tenant ID to use for indexed repositories")
+	repoID := flag.Uint("repo_id", 0, "opaque ID to use for indexed repositories. Surfaces as `RepositoryID` in the REST search response.")
 
 	cpuProfile := flag.String("cpuprofile", "", "write cpu profile to `file`")
 
@@ -77,6 +78,7 @@ func run() int {
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
 	opts.RepositoryDescription.TenantID = *tenantID
+	opts.RepositoryDescription.ID = uint32(*repoID)
 
 	var branches []string
 	if *branchesStr != "" {

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -251,8 +251,11 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 		}
 	}
 
-	id, _ := strconv.ParseUint(sec.Options.Get("repoid"), 10, 32)
-	desc.ID = uint32(id)
+	idString := sec.Options.Get("repoid")
+	if idString != "" {
+		id, _ := strconv.ParseUint(idString, 10, 32)
+		desc.ID = uint32(id)
+	}
 
 	if desc.RawConfig == nil {
 		desc.RawConfig = map[string]string{}


### PR DESCRIPTION
This PR adds the `repo_id` option to `zoekt-git-index`, allowing us to plumb a repository's database ID (Sourcebot ID) into it's corresponding shard(s) at index time. When an ID for a repository is present, it will surface as the `RepositoryID` property for each file match (see [here](https://github.com/sourcebot-dev/zoekt/blob/bkellam/plumb_id/api.go#L86)). This is useful for correlating additional metadata from the db.