### PR TITLE
chore: resolve open CodeQL security alerts

### DIFF
--- a/.github/workflows/buf-breaking-check.yml
+++ b/.github/workflows/buf-breaking-check.yml
@@ -4,6 +4,8 @@ on:
       - opened
     paths:
       - '*.proto'
+permissions:
+  contents: read
 jobs:
   validate-protos:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   workflow_dispatch:
 name: CI
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,8 +1,11 @@
 name: Semgrep - SAST Scan
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
+
+permissions:
+  contents: read
 
 jobs:
   semgrep:
@@ -16,9 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout semgrep-rules repo
         uses: actions/checkout@v4

--- a/api.go
+++ b/api.go
@@ -664,8 +664,8 @@ func (r *Repository) UnmarshalJSON(data []byte) error {
 	}
 
 	if v, ok := repo.RawConfig["tenantID"]; ok {
-		id, _ := strconv.ParseInt(v, 10, 64)
-		r.TenantID = int(id)
+		id, _ := strconv.Atoi(v)
+		r.TenantID = id
 	}
 
 	// Sourcegraph indexserver doesn't set repo.Rank, so we set it here. Setting it

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -603,7 +603,7 @@ func (sf sourcegraphFake) id(name string) uint32 {
 	// allow overriding the ID.
 	idPath := filepath.Join(sf.RootDir, filepath.FromSlash(name), "SG_ID")
 	if b, _ := os.ReadFile(idPath); len(b) > 0 {
-		id, err := strconv.Atoi(strings.TrimSpace(string(b)))
+		id, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 32)
 		if err == nil {
 			return uint32(id)
 		}

--- a/gitindex/clone.go
+++ b/gitindex/clone.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +26,28 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 )
+
+// redactURLCredentials removes any basic-auth userinfo from a URL-shaped
+// string so that credentials are never written to logs. Non-URL arguments
+// are returned unchanged.
+func redactURLCredentials(s string) string {
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme == "" || u.User == nil {
+		return s
+	}
+	u.User = url.User("redacted")
+	return u.String()
+}
+
+// redactURLCredentialsInArgs returns a copy of args with any URL-valued
+// arguments having their userinfo redacted.
+func redactURLCredentialsInArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = redactURLCredentials(a)
+	}
+	return out
+}
 
 // CloneRepo clones one repository, adding the given config
 // settings. It returns the bare repo directory. The `name` argument
@@ -57,7 +80,7 @@ func CloneRepo(destDir, name, cloneURL string, settings map[string]string) (stri
 
 	// Prevent prompting
 	cmd.Stdin = &bytes.Buffer{}
-	log.Println("running:", cmd.Args)
+	log.Println("running:", redactURLCredentialsInArgs(cmd.Args))
 	if err := cmd.Run(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

Resolves the 12 open CodeQL alerts on `sourcebot-dev/zoekt`.

### Open Dependabot alerts (informational)

Alerts #11 (grpc critical), #14 and #15 (otel medium/high) should be automatically closed on the next Dependabot rescan — they were fixed by the dependency bumps in #12 (already merged to main).  This PR does not need to touch Dependabot.

### CodeQL fixes in this PR

| Alert | Rule | Severity | Fix |
|---|---|---|---|
| #12 | `go/clear-text-logging` | high | Redact URL userinfo before logging `git clone` args in `gitindex/clone.go`. Exec args unchanged. |
| #13 | `go/incorrect-integer-conversion` | high | `api.go`: replace `ParseInt(_, 10, 64)` + `int()` with `strconv.Atoi` for `tenantID`. |
| #17 | `go/incorrect-integer-conversion` | high | `sg.go`: replace `Atoi` + `uint32()` with `ParseUint(_, 10, 32)` for `SG_ID`. |
| #2-8, #23 | `actions/missing-workflow-permissions` | medium | Add top-level `permissions: contents: read` to `ci.yml` and `buf-breaking-check.yml` (least-privilege default for `GITHUB_TOKEN`). |
| #1 | `actions/untrusted-checkout/high` | high | `semgrep.yml`: switch trigger from `pull_request_target` to `pull_request` so PR code is only ever checked out without write scopes / access to secrets like `GH_SEMGREP_SAST_TOKEN`. |

## Test plan

- [x] `go build ./...` passes.
- [x] `go test -count=1 -short ./gitindex/... ./cmd/zoekt-sourcegraph-indexserver/...` passes.
- [x] Verified `redactURLCredentials` behavior: `https://user:pass@github.com/foo/bar.git` → `https://redacted@github.com/foo/bar.git`; non-URL arguments (`--verbose`, `/tmp/foo.git`, `git@github.com:foo/bar.git`) pass through unchanged.